### PR TITLE
Adapt README to current Lara setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides a vagrant machine for development on the [ILSCeV/Lara](htt
 1. Install Git ([Windows](https://git-for-windows.github.io))
 2. Install [VirtualBox 5.1](https://www.virtualbox.org/wiki/Downloads)
 3. Install [Vagrant 1.9+](https://www.vagrantup.com/downloads.html)
-4. Open a console (Powershell, Git Bash, Terminal, ...)
+4. Open a console (Powershell, Git Bash, Terminal, ...). If you are on Windows, be sure to start the console with elevated rights (as Administrator).
  1. `git clone https://github.com/ILSCeV/homestead-Lara.git`
  2. `cd homestead-Lara`
  3. `init-lara.bat` / `init-lara.sh`
@@ -19,12 +19,27 @@ This project provides a vagrant machine for development on the [ILSCeV/Lara](htt
 7. (Use `restart-vm.bat` to restart the machine, if needed or after booting the host system)
 8. (Use `destroy.bat` to reset)
 
+## How to rebuild javascript/typescript libraries after your changes
+1. Ensure the VM is running (`vagrant up`).
+2. Open a shell in your Homstead-Lara directory.
+3. Run `vagrant ssh` to ssh to the VM.
+4. Switch to the Lara directory `cd /home/vagrant/Code/Lara`.
+5. Run `npm run dev` to build `*.js` files and the `mix-manifest.json`.
+
+## Rebuild npm dependencies in case of an error
+0. If you are on Windows ensure that you do the following steps as an Administrator.
+1. Open a shell in your Homestead directory and run `vagrant up && vagrant ssh` to ssh to the VM.
+2. Switch to the Lara directory `cd /home/vagrant/Code/Lara`.
+3. Delete old dependencies `rm -r node_modules`.
+4. Install dependencies `sudo npm install`.
+5. Build Javascript/Typescript fiels `npm run dev`.
+
 ## The details
 
 1. Git will be used to download this project and you will use it later to push changes.
 2. VirtualBox will be used as a virtualisation driver by Vagrant. You will not interact with it directly.
 3. Vagrant is a nifty tool to make creating and setting up a virtual machine a piece of cake. All you really need is one script file (`Vagrantfile`) which describes how the virtual machine should look and feel (OS, packages, mounts, network, portforwardings,...), the rest is done by Vagrant. magic.
-4. Choose any console you like.
+4. Choose any console you like. On a windows machine, you have to start this console as an administrator (in the start menu, rightclick and choose "Run as Administrator"). This is important as you need elevated rights, so that `npm install` can create symlinks.
  1. This step downloads this project. It is based on [homestead](https://laravel.com/docs/master/homestead), the official Laravel Vagrant-based development environment. The only modifications are in the files `Homestead.yaml` and `after.sh`.
  2. a not so complicated step.
  3. this will create copies of `Homestead.yaml` and `after.sh` for execution in your personal user folder. Additionally you you will be prompted for the repository and branch to clone from.


### PR DESCRIPTION
With the current build process of
[Lara](https://github.com/ILSCeV/Lara.git) we have to remind users to
use an elevated shell, so that `npm install` does not fail to create
symlinks.