### PR TITLE
Automatically ssh into Lara directory

### DIFF
--- a/resources/after.sh
+++ b/resources/after.sh
@@ -82,6 +82,8 @@ sudo service nginx restart
 #apt-get update
 #apt-get install phpmyadmin
 
+echo "cd /home/vagrant/Code/Lara" >> /home/vagrant/.bashrc
+
 echo "\n================================"
 echo "Lara: finished"
 echo "hack: ssh://vagrant:vagrant@localhost:2222"


### PR DESCRIPTION
Usually if you ssh into the vagrant VM, you want to run some artisan or
npm command. This means that you still have to do `cd Code/Lara` each
time you login to the VM. Adding a `cd` command to the `.bashrc` of the
VM enables the developer to go straight to the right directory.